### PR TITLE
Typo and path highlight bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ print(selector.get_support(indices=True))
 
 ### Bootstrapping strategies
 
-`stability-selection` uses bootstrapping without replacement by default (as proposed in the original paper), but does support different bootstrapping strategies. [Shah and Samworth] proposed *complentairy pairs* bootstrapping, where the data set is bootstrapped in pairs, such that the intersection is empty but the union equals the original data set. `StabilitySelection` supports this through the `bootstrap_func` parameter. 
+`stability-selection` uses bootstrapping without replacement by default (as proposed in the original paper), but does support different bootstrapping strategies. [Shah and Samworth] proposed *complementary pairs* bootstrapping, where the data set is bootstrapped in pairs, such that the intersection is empty but the union equals the original data set. `StabilitySelection` supports this through the `bootstrap_func` parameter.
 
 This parameter can be:
 - A string, which must be one of

--- a/stability_selection/stability_selection.py
+++ b/stability_selection/stability_selection.py
@@ -136,8 +136,9 @@ def plot_stability_path(stability_selection, threshold_highlight=None,
     x_grid = stability_selection.lambda_grid / np.max(stability_selection.lambda_grid)
 
     fig, ax = plt.subplots(1, 1, **kwargs)
-    ax.plot(x_grid, stability_selection.stability_scores_[~paths_to_highlight].T,
-            'k:', linewidth=0.5)
+    if not paths_to_highlight.all():
+        ax.plot(x_grid, stability_selection.stability_scores_[~paths_to_highlight].T,
+                'k:', linewidth=0.5)
 
     if paths_to_highlight.any():
         ax.plot(x_grid, stability_selection.stability_scores_[paths_to_highlight].T,


### PR DESCRIPTION
Two very small fixes:
- One typo fix in the README.md file of the word 'complementary'
- One conditional execution in stability selection plot; in the case where all paths were highlighted, this code would error on line 139 (plotting non-highlighted paths). There is an argument for saying then the regularisation parameter search range is not appropriate, but we can avoid the error by adding an if statement.