### PR TITLE
Import joblib directly, as sklearn.externals.joblib was removed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ nose>=1.1.2
 scikit-learn>=0.19
 matplotlib>=2.0.0
 numpy>=1.8.0
+joblib>=0.13

--- a/stability_selection/stability_selection.py
+++ b/stability_selection/stability_selection.py
@@ -23,7 +23,7 @@ from warnings import warn
 import matplotlib.pyplot as plt
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin, clone
-from sklearn.externals.joblib import Parallel, delayed
+from joblib import Parallel, delayed
 from sklearn.feature_selection import SelectFromModel
 from sklearn.linear_model import LogisticRegression
 from sklearn.pipeline import Pipeline


### PR DESCRIPTION
`sklearn.externals.joblib` [was deprecated in v0.21 of scikit-learn](https://scikit-learn.org/stable/whats_new/v0.21.html#miscellaneous), and has been removed in v0.23 (the latest stable release).

This PR imports directly from `joblib` and adds it as a dependency.

Fixes #33 